### PR TITLE
Correct logic gate for executing ndenv_npm :remove

### DIFF
--- a/providers/npm.rb
+++ b/providers/npm.rb
@@ -70,7 +70,7 @@ end
 action :remove do
   name = new_resource.package_name
   out = npm_command("-g ls #{name}", new_resource.node_version)
-  unless out.exitstatus == 0
+  if out.exitstatus == 0
     converge_by("Remove NPM package `#{name}` for node[#{new_resource.node_version}]..") do
       npm_command!("remove -g #{name}", new_resource.node_version)
       ndenv_command!('rehash')


### PR DESCRIPTION
```
npm -g ls <package>
```
exits with 0 if the package is _installed_. So we want to execute removal _if_ the exit code is 0, rather than _unless_ the exit code is 0.